### PR TITLE
Add Content-Type to HTTPClient requests

### DIFF
--- a/rpc/HTTPClient.php
+++ b/rpc/HTTPClient.php
@@ -95,6 +95,7 @@ class XBMC_RPC_HTTPClient extends XBMC_RPC_Client {
             $this->curlResource = $this->createCurlResource();
         }
         curl_setopt($this->curlResource, CURLOPT_POSTFIELDS, $json);
+        curl_setopt($this->curlResource, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
         if (!$response = curl_exec($this->curlResource)) {
             throw new XBMC_RPC_RequestException('Could not make a request the server');
         }


### PR DESCRIPTION
"Content-Type" is now needed by the API v6 (http://wiki.xbmc.org/index.php?title=Frodo_API_Changes#JSON-RPC_Handler_.2Fjsonrpc)

It fixes the example.php, I did not test it further.
